### PR TITLE
Some fixes and upgrades, comply with XEP-0156

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '24 14 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:12-alpine AS builder
 
 WORKDIR /opt/mx-puppet-xmpp
 
@@ -34,7 +34,7 @@ COPY src/ ./src/
 RUN npm run build
 
 
-FROM node:alpine
+FROM node:12-alpine
 
 VOLUME /data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,27 +8,23 @@
       "name": "mx-puppet-xmpp",
       "version": "0.0.0",
       "dependencies": {
-        "@sorunome/xmpp-http": "^1.5.2",
         "@xmpp/client": "^0.13.0",
+        "@xmpp/client-core": "^0.13.1",
         "cheerio": "^1.0.0-rc.3",
         "command-line-args": "^5.1.1",
         "command-line-usage": "^5.0.5",
         "decode-html": "^2.0.0",
         "escape-html": "^1.0.3",
-        "events": "^3.0.0",
         "expire-set": "^1.0.0",
         "js-yaml": "^3.13.1",
         "mx-puppet-bridge": "0.1.6",
         "node-emoji": "^1.10.0",
         "node-html-parser": "^1.2.13",
-        "tough-cookie": "^4.0.0",
         "tslint": "^5.17.0",
         "typescript": "^3.7.4"
       },
       "devDependencies": {
-        "@types/mocha": "^7.0.2",
-        "@types/node": "^12.0.8",
-        "@types/tough-cookie": "^4.0.0"
+        "@types/node": "^12.0.8"
       }
     },
     "node_modules/@babel/cli": {
@@ -36,6 +32,8 @@
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.15.7.tgz",
       "integrity": "sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==",
       "dependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -537,17 +535,6 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
-      "integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@sorunome/matrix-bot-sdk": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/@sorunome/matrix-bot-sdk/-/matrix-bot-sdk-0.5.13.tgz",
@@ -716,25 +703,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sorunome/xmpp-http": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@sorunome/xmpp-http/-/xmpp-http-1.5.2.tgz",
-      "integrity": "sha512-NAxvVVHIi7G/9v5RbB3vkNqbgy2CB+puE6ZvwX1ha4+PCP5MTy5KZRfrhOpIVyTLmTEXS50USl/ixAek5RwLlA==",
-      "dependencies": {
-        "async-file": "^2.0.2",
-        "big-integer": "^1.6.26",
-        "bluebird": "^3.5.1",
-        "cheerio": "^1.0.0-rc.3",
-        "escape-html": "^1.0.3",
-        "got": "^10.7.0",
-        "incident": "^3.2.0",
-        "js-sha256": "^0.9.0",
-        "kryo": "^0.8.1",
-        "lodash": "^4.17.15",
-        "tough-cookie": "^4.0.0",
-        "tunnel": "0.0.6"
-      }
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
@@ -752,14 +720,6 @@
       "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
       "dependencies": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/bson": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-1.0.11.tgz",
-      "integrity": "sha512-j+UcCWI+FsbI5/FQP/Kj2CXyplWAz39ktHFkXk84h7dNblKRSoNJs95PZFRd96NQGqsPEPgeclqnznWZr14ZDA==",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -821,21 +781,10 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
-    "node_modules/@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "12.12.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
       "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
-    },
-    "node_modules/@types/object-inspect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.6.1.tgz",
-      "integrity": "sha512-i+IgNcDl9bt2z9kwUdwNJQ4aVdZ9jVhjTCfH/YU2amkZIaHFPGSwpfarBzEOY0Pc5eGsei53CO0SiBn27vj1VA=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -863,12 +812,6 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-      "dev": true
     },
     "node_modules/@xmpp/base64": {
       "version": "0.13.0",
@@ -914,27 +857,27 @@
       }
     },
     "node_modules/@xmpp/client-core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/client-core/-/client-core-0.13.0.tgz",
-      "integrity": "sha512-ZBBR/L/oNJD2O2RwGYsQsCH+sVcDEEEJ/KsxQENO4bfW/k3RqXKkXyRmGL/bwHuF94u6XlIHfmv7kyiOayIiUw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/client-core/-/client-core-0.13.1.tgz",
+      "integrity": "sha512-ANVcqzgDCmmUj/R9pf5rJGH41mL16Bo+DRJ+2trKoRHe9p5s0p6IssjhJtTOSVx6oh2ilPXMB8qoMPjTGzY6cw==",
       "dependencies": {
-        "@xmpp/connection": "^0.13.0",
-        "@xmpp/jid": "^0.13.0",
-        "@xmpp/xml": "^0.13.0"
+        "@xmpp/connection": "^0.13.1",
+        "@xmpp/jid": "^0.13.1",
+        "@xmpp/xml": "^0.13.1"
       },
       "engines": {
         "node": ">= 12.4.0"
       }
     },
     "node_modules/@xmpp/connection": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/connection/-/connection-0.13.0.tgz",
-      "integrity": "sha512-8aLM+XsHYfI/Q7DsOAClEgA825eHIztCZVP4z+diAYuyhyN1P0e4en1dQjK7QOVvOg+DsA8qTcZ8C0b3pY7EFw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/connection/-/connection-0.13.1.tgz",
+      "integrity": "sha512-A8ojaVRrvGtvRTXcWiOJMnBPAytLFvsz18g/jO9PbnhzuqqeJ6LxmCtyaKqchMdX0lhuZpo0JUgCSPnZ68tXrQ==",
       "dependencies": {
-        "@xmpp/error": "^0.13.0",
-        "@xmpp/events": "^0.13.0",
-        "@xmpp/jid": "^0.13.0",
-        "@xmpp/xml": "^0.13.0"
+        "@xmpp/error": "^0.13.1",
+        "@xmpp/events": "^0.13.1",
+        "@xmpp/jid": "^0.13.1",
+        "@xmpp/xml": "^0.13.1"
       },
       "engines": {
         "node": ">= 12.4.0"
@@ -953,17 +896,17 @@
       }
     },
     "node_modules/@xmpp/error": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/error/-/error-0.13.0.tgz",
-      "integrity": "sha512-cTyGMrXzuEulRiG29vvHhaU0vTpOxDQS49dyUAW+2Rj5ex9OXXGiWWbJDodEO9B/rHiUXr1U63818Yv4lxZJBA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/error/-/error-0.13.1.tgz",
+      "integrity": "sha512-tKecj36xIGLhLctdYhUOxWs+ZdiJpl0Tfp/GhfrUCKLHj/wq14d62SP9kxa0sDNKOY1uqRq2N9gWZBQHuP+r2Q==",
       "engines": {
         "node": ">= 12.4.0"
       }
     },
     "node_modules/@xmpp/events": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/events/-/events-0.13.0.tgz",
-      "integrity": "sha512-G+9NczMWWOawn62r1JIv/N413G2biI+hURiN4iH74FGvjagXwassUeJgPnDUEFp2FTKX3dIrJDkXH49ZcFuo/g==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/events/-/events-0.13.1.tgz",
+      "integrity": "sha512-c538zWUoD7KfMzMWGHyJkXvRYE5exzVjK6NAsMtfNtbVqw9SXJJaGLvDvYSXOQmKQaZz5guUuIUGiHJbr7yjsA==",
       "dependencies": {
         "events": "^3.3.0"
       },
@@ -994,9 +937,9 @@
       }
     },
     "node_modules/@xmpp/jid": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.13.0.tgz",
-      "integrity": "sha512-R8XkQOLK7V+wDiXozc9VzoACb4+XPR6K8zno1fur9le7AnUrX/vUvb8/ZcvenFNWVYplvZS6h9GkZPPEGvmUyQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.13.1.tgz",
+      "integrity": "sha512-E5ulk4gfPQwPY71TWXapiWzoxxAJz3LP0bDIUXIfgvlf1/2QKP3EcYQ7o+qmI0cLEZwWmwluRGouylqhyuwcAw==",
       "engines": {
         "node": ">= 12.4.0"
       }
@@ -1177,9 +1120,9 @@
       }
     },
     "node_modules/@xmpp/xml": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.13.0.tgz",
-      "integrity": "sha512-bgKaUzzJXp8nXCQPzVRJLy1XZQlLrcmjzUe1V7127NcXJddEgk1Ie/esVhh1BUMlPgRdl7BCRQkYe40S6KuuXw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.13.1.tgz",
+      "integrity": "sha512-GMfYB3PKY9QzsMnl3dPohgPBGd1JQTBanKOaZexJCSYJN2cdYLU2HGhjMtDlGSno6h9U+t0oO7r0igsJwyigwg==",
       "dependencies": {
         "ltx": "^3.0.0"
       },
@@ -1310,14 +1253,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-    },
-    "node_modules/async-file": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
-      "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
-      "dependencies": {
-        "rimraf": "^2.5.2"
-      }
     },
     "node_modules/babel-plugin-jsx-pragmatic": {
       "version": "1.0.2",
@@ -1457,14 +1392,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1501,11 +1428,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/blurhash": {
       "version": "1.1.3",
@@ -1580,15 +1502,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/bson": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-      "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1639,18 +1552,6 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
-      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-      "dependencies": {
-        "@types/keyv": "^3.1.1",
-        "keyv": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cacheable-request": {
@@ -1742,6 +1643,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2059,17 +1961,6 @@
       "resolved": "https://registry.npmjs.org/decode-html/-/decode-html-2.0.0.tgz",
       "integrity": "sha1-fQqIfORCgOYJeKcH67f4CB/WHqo="
     },
-    "node_modules/decompress-response": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2172,11 +2063,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2649,34 +2535,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/got": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
-      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
-      "dependencies": {
-        "@sindresorhus/is": "^2.0.0",
-        "@szmarczak/http-timer": "^4.0.0",
-        "@types/cacheable-request": "^6.0.1",
-        "cacheable-lookup": "^2.0.0",
-        "cacheable-request": "^7.0.1",
-        "decompress-response": "^5.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^5.0.0",
-        "lowercase-keys": "^2.0.0",
-        "mimic-response": "^2.1.0",
-        "p-cancelable": "^2.0.0",
-        "p-event": "^4.0.0",
-        "responselike": "^2.0.0",
-        "to-readable-stream": "^2.0.0",
-        "type-fest": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -3020,15 +2878,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "node_modules/incident": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/incident/-/incident-3.2.1.tgz",
-      "integrity": "sha512-Mejx4QijYGSBAaR8NobH5dhFC7h5q1bIClsAtdoTEl/YzqSYVE/5WgovlYUHqwdBTLHkptQ5bv9nJNsJCJDeXg==",
-      "dependencies": {
-        "@types/object-inspect": "^1.4.0",
-        "object-inspect": "^1.6.0"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3307,11 +3156,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3387,20 +3231,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
-    },
-    "node_modules/kryo": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/kryo/-/kryo-0.8.1.tgz",
-      "integrity": "sha512-7EAfYnIEGZXH+V4pP9ekalnqyx7xAUMgbJkK2SwLytAkPdv+p7W9rUVam0yZDQw439bhLMKKB26XfCOxZGpH/w==",
-      "dependencies": {
-        "@types/bson": "^1.0.11",
-        "@types/object-inspect": "^1.4.0",
-        "incident": "^3.1.1",
-        "object-inspect": "^1.6.0"
-      },
-      "optionalDependencies": {
-        "bson": "^1.1.0"
-      }
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -4155,25 +3985,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-event": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-      "dependencies": {
-        "p-timeout": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -4197,17 +4008,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-try": {
@@ -4527,11 +4327,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4539,14 +4334,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -5256,14 +5043,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/to-readable-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
-      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5282,19 +5061,6 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -5352,14 +5118,6 @@
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5369,17 +5127,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-      "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -5442,14 +5189,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -5681,15 +5420,15 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -6079,11 +5818,6 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
     },
-    "@sindresorhus/is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
-      "integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg=="
-    },
     "@sorunome/matrix-bot-sdk": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/@sorunome/matrix-bot-sdk/-/matrix-bot-sdk-0.5.13.tgz",
@@ -6195,25 +5929,6 @@
         }
       }
     },
-    "@sorunome/xmpp-http": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@sorunome/xmpp-http/-/xmpp-http-1.5.2.tgz",
-      "integrity": "sha512-NAxvVVHIi7G/9v5RbB3vkNqbgy2CB+puE6ZvwX1ha4+PCP5MTy5KZRfrhOpIVyTLmTEXS50USl/ixAek5RwLlA==",
-      "requires": {
-        "async-file": "^2.0.2",
-        "big-integer": "^1.6.26",
-        "bluebird": "^3.5.1",
-        "cheerio": "^1.0.0-rc.3",
-        "escape-html": "^1.0.3",
-        "got": "^10.7.0",
-        "incident": "^3.2.0",
-        "js-sha256": "^0.9.0",
-        "kryo": "^0.8.1",
-        "lodash": "^4.17.15",
-        "tough-cookie": "^4.0.0",
-        "tunnel": "0.0.6"
-      }
-    },
     "@szmarczak/http-timer": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
@@ -6228,14 +5943,6 @@
       "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
       "requires": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/bson": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-1.0.11.tgz",
-      "integrity": "sha512-j+UcCWI+FsbI5/FQP/Kj2CXyplWAz39ktHFkXk84h7dNblKRSoNJs95PZFRd96NQGqsPEPgeclqnznWZr14ZDA==",
-      "requires": {
         "@types/node": "*"
       }
     },
@@ -6297,21 +6004,10 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
-    "@types/mocha": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
-      "dev": true
-    },
     "@types/node": {
       "version": "12.12.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
       "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
-    },
-    "@types/object-inspect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.6.1.tgz",
-      "integrity": "sha512-i+IgNcDl9bt2z9kwUdwNJQ4aVdZ9jVhjTCfH/YU2amkZIaHFPGSwpfarBzEOY0Pc5eGsei53CO0SiBn27vj1VA=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -6339,12 +6035,6 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-      "dev": true
     },
     "@xmpp/base64": {
       "version": "0.13.0",
@@ -6384,24 +6074,24 @@
       }
     },
     "@xmpp/client-core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/client-core/-/client-core-0.13.0.tgz",
-      "integrity": "sha512-ZBBR/L/oNJD2O2RwGYsQsCH+sVcDEEEJ/KsxQENO4bfW/k3RqXKkXyRmGL/bwHuF94u6XlIHfmv7kyiOayIiUw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/client-core/-/client-core-0.13.1.tgz",
+      "integrity": "sha512-ANVcqzgDCmmUj/R9pf5rJGH41mL16Bo+DRJ+2trKoRHe9p5s0p6IssjhJtTOSVx6oh2ilPXMB8qoMPjTGzY6cw==",
       "requires": {
-        "@xmpp/connection": "^0.13.0",
-        "@xmpp/jid": "^0.13.0",
-        "@xmpp/xml": "^0.13.0"
+        "@xmpp/connection": "^0.13.1",
+        "@xmpp/jid": "^0.13.1",
+        "@xmpp/xml": "^0.13.1"
       }
     },
     "@xmpp/connection": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/connection/-/connection-0.13.0.tgz",
-      "integrity": "sha512-8aLM+XsHYfI/Q7DsOAClEgA825eHIztCZVP4z+diAYuyhyN1P0e4en1dQjK7QOVvOg+DsA8qTcZ8C0b3pY7EFw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/connection/-/connection-0.13.1.tgz",
+      "integrity": "sha512-A8ojaVRrvGtvRTXcWiOJMnBPAytLFvsz18g/jO9PbnhzuqqeJ6LxmCtyaKqchMdX0lhuZpo0JUgCSPnZ68tXrQ==",
       "requires": {
-        "@xmpp/error": "^0.13.0",
-        "@xmpp/events": "^0.13.0",
-        "@xmpp/jid": "^0.13.0",
-        "@xmpp/xml": "^0.13.0"
+        "@xmpp/error": "^0.13.1",
+        "@xmpp/events": "^0.13.1",
+        "@xmpp/jid": "^0.13.1",
+        "@xmpp/xml": "^0.13.1"
       }
     },
     "@xmpp/connection-tcp": {
@@ -6414,14 +6104,14 @@
       }
     },
     "@xmpp/error": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/error/-/error-0.13.0.tgz",
-      "integrity": "sha512-cTyGMrXzuEulRiG29vvHhaU0vTpOxDQS49dyUAW+2Rj5ex9OXXGiWWbJDodEO9B/rHiUXr1U63818Yv4lxZJBA=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/error/-/error-0.13.1.tgz",
+      "integrity": "sha512-tKecj36xIGLhLctdYhUOxWs+ZdiJpl0Tfp/GhfrUCKLHj/wq14d62SP9kxa0sDNKOY1uqRq2N9gWZBQHuP+r2Q=="
     },
     "@xmpp/events": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/events/-/events-0.13.0.tgz",
-      "integrity": "sha512-G+9NczMWWOawn62r1JIv/N413G2biI+hURiN4iH74FGvjagXwassUeJgPnDUEFp2FTKX3dIrJDkXH49ZcFuo/g==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/events/-/events-0.13.1.tgz",
+      "integrity": "sha512-c538zWUoD7KfMzMWGHyJkXvRYE5exzVjK6NAsMtfNtbVqw9SXJJaGLvDvYSXOQmKQaZz5guUuIUGiHJbr7yjsA==",
       "requires": {
         "events": "^3.3.0"
       }
@@ -6443,9 +6133,9 @@
       }
     },
     "@xmpp/jid": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.13.0.tgz",
-      "integrity": "sha512-R8XkQOLK7V+wDiXozc9VzoACb4+XPR6K8zno1fur9le7AnUrX/vUvb8/ZcvenFNWVYplvZS6h9GkZPPEGvmUyQ=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.13.1.tgz",
+      "integrity": "sha512-E5ulk4gfPQwPY71TWXapiWzoxxAJz3LP0bDIUXIfgvlf1/2QKP3EcYQ7o+qmI0cLEZwWmwluRGouylqhyuwcAw=="
     },
     "@xmpp/middleware": {
       "version": "0.13.0",
@@ -6578,9 +6268,9 @@
       }
     },
     "@xmpp/xml": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.13.0.tgz",
-      "integrity": "sha512-bgKaUzzJXp8nXCQPzVRJLy1XZQlLrcmjzUe1V7127NcXJddEgk1Ie/esVhh1BUMlPgRdl7BCRQkYe40S6KuuXw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.13.1.tgz",
+      "integrity": "sha512-GMfYB3PKY9QzsMnl3dPohgPBGd1JQTBanKOaZexJCSYJN2cdYLU2HGhjMtDlGSno6h9U+t0oO7r0igsJwyigwg==",
       "requires": {
         "ltx": "^3.0.0"
       }
@@ -6693,14 +6383,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
-    "async-file": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
-      "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
-      "requires": {
-        "rimraf": "^2.5.2"
-      }
-    },
     "babel-plugin-jsx-pragmatic": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-1.0.2.tgz",
@@ -6804,11 +6486,6 @@
         }
       }
     },
-    "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6842,11 +6519,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "blurhash": {
       "version": "1.1.3",
@@ -6905,12 +6577,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "bson": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-      "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
-      "optional": true
-    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -6939,15 +6605,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "cacheable-lookup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
-      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-      "requires": {
-        "@types/keyv": "^3.1.1",
-        "keyv": "^4.0.0"
-      }
     },
     "cacheable-request": {
       "version": "7.0.1",
@@ -7296,14 +6953,6 @@
       "resolved": "https://registry.npmjs.org/decode-html/-/decode-html-2.0.0.tgz",
       "integrity": "sha1-fQqIfORCgOYJeKcH67f4CB/WHqo="
     },
-    "decompress-response": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
-      "requires": {
-        "mimic-response": "^2.0.0"
-      }
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -7382,11 +7031,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -7760,28 +7404,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
-    "got": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
-      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
-      "requires": {
-        "@sindresorhus/is": "^2.0.0",
-        "@szmarczak/http-timer": "^4.0.0",
-        "@types/cacheable-request": "^6.0.1",
-        "cacheable-lookup": "^2.0.0",
-        "cacheable-request": "^7.0.1",
-        "decompress-response": "^5.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^5.0.0",
-        "lowercase-keys": "^2.0.0",
-        "mimic-response": "^2.1.0",
-        "p-cancelable": "^2.0.0",
-        "p-event": "^4.0.0",
-        "responselike": "^2.0.0",
-        "to-readable-stream": "^2.0.0",
-        "type-fest": "^0.10.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -8031,15 +7653,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "incident": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/incident/-/incident-3.2.1.tgz",
-      "integrity": "sha512-Mejx4QijYGSBAaR8NobH5dhFC7h5q1bIClsAtdoTEl/YzqSYVE/5WgovlYUHqwdBTLHkptQ5bv9nJNsJCJDeXg==",
-      "requires": {
-        "@types/object-inspect": "^1.4.0",
-        "object-inspect": "^1.6.0"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -8228,11 +7841,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8287,18 +7895,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
       "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
-    },
-    "kryo": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/kryo/-/kryo-0.8.1.tgz",
-      "integrity": "sha512-7EAfYnIEGZXH+V4pP9ekalnqyx7xAUMgbJkK2SwLytAkPdv+p7W9rUVam0yZDQw439bhLMKKB26XfCOxZGpH/w==",
-      "requires": {
-        "@types/bson": "^1.0.11",
-        "@types/object-inspect": "^1.4.0",
-        "bson": "^1.1.0",
-        "incident": "^3.1.1",
-        "object-inspect": "^1.6.0"
-      }
     },
     "kuler": {
       "version": "2.0.0",
@@ -8898,19 +8494,6 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
       "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
     },
-    "p-event": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-      "requires": {
-        "p-timeout": "^2.0.1"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -8925,14 +8508,6 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
         "p-limit": "^2.0.0"
-      }
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -9166,11 +8741,6 @@
         "ipaddr.js": "1.9.1"
       }
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9179,11 +8749,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.7.0",
@@ -9739,11 +9304,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
-    "to-readable-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
-      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w=="
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9757,16 +9317,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-      "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
-      }
     },
     "tr46": {
       "version": "0.0.3",
@@ -9811,11 +9361,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -9823,11 +9368,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "type-fest": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-      "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -9871,11 +9411,6 @@
       "requires": {
         "extend-shallow": "^2.0.1"
       }
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -10074,9 +9609,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -12,24 +12,21 @@
   "author": "rkd",
   "dependencies": {
     "@xmpp/client": "^0.13.0",
+    "@xmpp/client-core": "^0.13.1",
     "cheerio": "^1.0.0-rc.3",
     "command-line-args": "^5.1.1",
     "command-line-usage": "^5.0.5",
     "decode-html": "^2.0.0",
     "escape-html": "^1.0.3",
-    "events": "^3.0.0",
     "expire-set": "^1.0.0",
     "js-yaml": "^3.13.1",
     "mx-puppet-bridge": "0.1.6",
     "node-emoji": "^1.10.0",
     "node-html-parser": "^1.2.13",
-    "tough-cookie": "^4.0.0",
     "tslint": "^5.17.0",
     "typescript": "^3.7.4"
   },
   "devDependencies": {
-    "@types/mocha": "^7.0.2",
-    "@types/node": "^12.0.8",
-    "@types/tough-cookie": "^4.0.0"
+    "@types/node": "^12.0.8"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import { EventEmitter } from "events";
 import { client, xml } from "@xmpp/client";
 import { Client as XmppClient } from "@xmpp/client-core";
 import * as Parser from "node-html-parser";
+import fetch from "node-fetch";
 
 const log = new Log("XmppPuppet:client");
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -78,7 +78,7 @@ export class Client extends EventEmitter {
 		this.api = client({
 			service: websocketUrl,
 			domain: this.domain,
-			resource: "mx_bridge",
+			//resource: "mx_bridge",
 			username: this.username,
 			password: this.password,
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,9 @@ async function run() {
 			const client = new Client(username, password);
 			await client.connect();
 			data.state = client.getState;
-			await client.disconnect();
+			setTimeout(async () => {
+				await client.disconnect();
+			}, 2000);
 		} catch (err) {
 			log.verbose("Failed to log in as new user, perhaps the password is wrong?");
 			log.silly(err);


### PR DESCRIPTION
I wanted to use this and it failed to build, so I made some fixes:
- locked Node version to 12 in Dockerfile as that was most likely what it was originally made for
- respect [XEP-0156](https://xmpp.org/extensions/xep-0156.html), so one can use this when they don't have the same XMPP domain and server and use a different port as well
- possibly fixed/reduced/worked around errors with websocket initialization and "replaced by new connection" messages
- added Github action to publish a container to ghcr