### PR TITLE
Add Docker Compose end-to-end tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,23 @@
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run Docker Compose E2E suite
+        run: ./test/e2e/run.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,4 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Run Docker Compose E2E suite
-        run: ./test/e2e/run.sh
+        shell: bash
+        run: |
+          set -o pipefail
+          ./test/e2e/run.sh 2>&1 | tee e2e.log
+      - name: Upload E2E failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-log
+          path: e2e.log
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -71,4 +71,24 @@ npm ci
 npm run check
 ```
 
-`npm run check` runs ESLint, TypeScript compilation, and the Node test suite.
+`npm run check` runs ESLint, TypeScript compilation, the Node unit tests, native dependency smoke tests, and the critical-level dependency audit.
+
+### End-to-end tests
+
+The E2E suite is self-contained and requires only Docker with Compose v2:
+
+```sh
+npm run test:e2e
+```
+
+It builds the current bridge image and starts isolated Synapse and Prosody containers, generates the Matrix application-service registration, creates Matrix/XMPP test accounts, links the XMPP account through the real bridge bot flow, and then tears the stack down including its volumes.
+
+The black-box suite verifies:
+
+1. invalid XMPP credentials are rejected rather than creating a link;
+2. valid XMPP credentials create a puppet;
+3. body-less XMPP message stanzas do not break the bridge;
+4. XMPP → Matrix text delivery;
+5. Matrix → XMPP text delivery.
+
+On failure, the runner prints the full Compose service state and logs before cleanup. The same suite runs automatically in the `E2E` GitHub Actions workflow.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "lint": "eslint 'src/**/*.ts'",
     "test": "npm run build && node --test test/**/*.test.js",
+    "test:e2e": "sh test/e2e/run.sh",
     "test:native": "node -e \"const Database=require('better-sqlite3'); const db=new Database(':memory:'); db.prepare('SELECT 1').get(); db.close(); const {createCanvas}=require('canvas'); const canvas=createCanvas(1,1); if(canvas.width!==1||canvas.height!==1) process.exit(1);\"",
     "audit": "npm audit --audit-level=critical",
     "check": "npm run lint && npm test && npm run test:native && npm run audit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import {
 	Log,
 	PuppetBridge,
 } from "mx-puppet-bridge";
-import * as commandLineArgs from "command-line-args";
-import * as commandLineUsage from "command-line-usage";
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
 import { Client } from "./client";
 import { Xmpp } from "./xmpp";
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,15 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+test("CLI renders help under the supported Node runtime", () => {
+  const output = execFileSync(
+    process.execPath,
+    [path.join(__dirname, "..", "build", "index.js"), "--help"],
+    { encoding: "utf8" },
+  );
+
+  assert.match(output, /Matrix XMPP Puppet Bridge/);
+  assert.match(output, /--register/);
+});

--- a/test/e2e/bridge-config.yaml
+++ b/test/e2e/bridge-config.yaml
@@ -1,0 +1,26 @@
+bridge:
+  bindAddress: 0.0.0.0
+  port: 8438
+  domain: matrix.test
+  homeserverUrl: http://synapse:8008
+
+logging:
+  console: info
+  files: []
+
+database:
+  filename: /data/database.db
+
+provisioning:
+  whitelist:
+    - ".*"
+
+presence:
+  enabled: false
+
+relay:
+  whitelist: []
+
+namePatterns:
+  user: ":name"
+  room: ":name"

--- a/test/e2e/bridge-registration-config.yaml
+++ b/test/e2e/bridge-registration-config.yaml
@@ -1,0 +1,28 @@
+bridge:
+  # Registration generation needs the Docker DNS name; the running bridge
+  # binds 0.0.0.0 via bridge-config.yaml.
+  bindAddress: bridge
+  port: 8438
+  domain: matrix.test
+  homeserverUrl: http://synapse:8008
+
+logging:
+  console: info
+  files: []
+
+database:
+  filename: /data/database.db
+
+provisioning:
+  whitelist:
+    - ".*"
+
+presence:
+  enabled: false
+
+relay:
+  whitelist: []
+
+namePatterns:
+  user: ":name"
+  room: ":name"

--- a/test/e2e/compose.yaml
+++ b/test/e2e/compose.yaml
@@ -1,0 +1,116 @@
+name: mx-puppet-xmpp-e2e
+
+services:
+  bridge-registration:
+    build:
+      context: ../..
+    image: mx-puppet-xmpp:e2e
+    restart: "no"
+    volumes:
+      - bridge-data:/data
+      - ./bridge-registration-config.yaml:/data/config.yaml:ro
+
+  synapse-generate:
+    image: matrixdotorg/synapse:v1.158.0
+    restart: "no"
+    environment:
+      SYNAPSE_SERVER_NAME: matrix.test
+      SYNAPSE_REPORT_STATS: "no"
+    volumes:
+      - synapse-data:/data
+    command: ["generate"]
+
+  prosody-init:
+    image: prosodyim/prosody:13.0@sha256:e44a7dfedb776c8945b5c6401a3437a009b549923f7bbcb5a480c2de5f86e5d7
+    restart: "no"
+    environment:
+      PROSODY_VIRTUAL_HOSTS: xmpp.test
+      PROSODY_NETWORK_HOSTNAME: prosody
+      PROSODY_ENABLE_MODULES: websocket
+      LOCAL: alice
+      DOMAIN: xmpp.test
+      PASSWORD: alicepass
+    volumes:
+      - prosody-data:/var/lib/prosody
+      - ./prosody-e2e.cfg.lua:/etc/prosody/conf.d/e2e.cfg.lua:ro
+    command: ["register", "bob", "xmpp.test", "bobpass"]
+
+  prosody:
+    image: prosodyim/prosody:13.0@sha256:e44a7dfedb776c8945b5c6401a3437a009b549923f7bbcb5a480c2de5f86e5d7
+    depends_on:
+      prosody-init:
+        condition: service_completed_successfully
+    environment:
+      PROSODY_VIRTUAL_HOSTS: xmpp.test
+      PROSODY_NETWORK_HOSTNAME: prosody
+      PROSODY_ENABLE_MODULES: websocket
+    volumes:
+      - prosody-data:/var/lib/prosody
+      - ./prosody-e2e.cfg.lua:/etc/prosody/conf.d/e2e.cfg.lua:ro
+    healthcheck:
+      test: ["CMD-SHELL", "prosodyctl status >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 2s
+
+  synapse:
+    image: matrixdotorg/synapse:v1.158.0
+    depends_on:
+      bridge-registration:
+        condition: service_completed_successfully
+      synapse-generate:
+        condition: service_completed_successfully
+    volumes:
+      - synapse-data:/data
+      - bridge-data:/bridge:ro
+      - ./synapse-overrides.yaml:/config/e2e.yaml:ro
+    command: ["run", "-c", "/data/homeserver.yaml", "-c", "/config/e2e.yaml"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fSs http://localhost:8008/health >/dev/null"]
+      interval: 2s
+      timeout: 2s
+      retries: 45
+      start_period: 5s
+
+  bridge:
+    build:
+      context: ../..
+    image: mx-puppet-xmpp:e2e
+    depends_on:
+      bridge-registration:
+        condition: service_completed_successfully
+      synapse:
+        condition: service_healthy
+      prosody:
+        condition: service_healthy
+    environment:
+      XMPP_WEBSOCKET_URL: ws://prosody:5280/xmpp-websocket
+      XMPP_ALLOW_INSECURE_WEBSOCKET: "true"
+    volumes:
+      - bridge-data:/data
+      - ./bridge-config.yaml:/data/config.yaml:ro
+
+  e2e:
+    image: mx-puppet-xmpp:e2e
+    depends_on:
+      bridge:
+        condition: service_started
+      synapse:
+        condition: service_healthy
+      prosody:
+        condition: service_healthy
+    entrypoint: ["/usr/local/bin/node", "/e2e/run.mjs"]
+    environment:
+      MATRIX_URL: http://synapse:8008
+      MATRIX_DOMAIN: matrix.test
+      MATRIX_REGISTRATION_SECRET: e2e-registration-secret
+      XMPP_URL: ws://prosody:5280/xmpp-websocket
+      XMPP_DOMAIN: xmpp.test
+    volumes:
+      - ./run.mjs:/e2e/run.mjs:ro
+
+volumes:
+  bridge-data:
+  prosody-data:
+  synapse-data:

--- a/test/e2e/compose.yaml
+++ b/test/e2e/compose.yaml
@@ -20,16 +20,28 @@ services:
       - synapse-data:/data
     command: ["generate"]
 
-  prosody-init:
+  prosody-init-alice:
     image: prosodyim/prosody:13.0@sha256:e44a7dfedb776c8945b5c6401a3437a009b549923f7bbcb5a480c2de5f86e5d7
     restart: "no"
     environment:
       PROSODY_VIRTUAL_HOSTS: xmpp.test
       PROSODY_NETWORK_HOSTNAME: prosody
       PROSODY_ENABLE_MODULES: websocket
-      LOCAL: alice
-      DOMAIN: xmpp.test
-      PASSWORD: alicepass
+    volumes:
+      - prosody-data:/var/lib/prosody
+      - ./prosody-e2e.cfg.lua:/etc/prosody/conf.d/e2e.cfg.lua:ro
+    command: ["register", "alice", "xmpp.test", "alicepass"]
+
+  prosody-init-bob:
+    image: prosodyim/prosody:13.0@sha256:e44a7dfedb776c8945b5c6401a3437a009b549923f7bbcb5a480c2de5f86e5d7
+    restart: "no"
+    depends_on:
+      prosody-init-alice:
+        condition: service_completed_successfully
+    environment:
+      PROSODY_VIRTUAL_HOSTS: xmpp.test
+      PROSODY_NETWORK_HOSTNAME: prosody
+      PROSODY_ENABLE_MODULES: websocket
     volumes:
       - prosody-data:/var/lib/prosody
       - ./prosody-e2e.cfg.lua:/etc/prosody/conf.d/e2e.cfg.lua:ro
@@ -38,7 +50,7 @@ services:
   prosody:
     image: prosodyim/prosody:13.0@sha256:e44a7dfedb776c8945b5c6401a3437a009b549923f7bbcb5a480c2de5f86e5d7
     depends_on:
-      prosody-init:
+      prosody-init-bob:
         condition: service_completed_successfully
     environment:
       PROSODY_VIRTUAL_HOSTS: xmpp.test

--- a/test/e2e/compose.yaml
+++ b/test/e2e/compose.yaml
@@ -60,7 +60,10 @@ services:
       - prosody-data:/var/lib/prosody
       - ./prosody-e2e.cfg.lua:/etc/prosody/conf.d/e2e.cfg.lua:ro
     healthcheck:
-      test: ["CMD-SHELL", "prosodyctl status >/dev/null 2>&1"]
+      # The official image runs Prosody in the foreground (`prosody -F`), so
+      # probe the WebSocket HTTP listener that the bridge actually depends on
+      # instead of using process-control-oriented `prosodyctl status`.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/5280"]
       interval: 2s
       timeout: 2s
       retries: 30

--- a/test/e2e/prosody-e2e.cfg.lua
+++ b/test/e2e/prosody-e2e.cfg.lua
@@ -1,0 +1,3 @@
+-- E2E-only settings. The test network is private to Docker Compose.
+c2s_require_encryption = false
+consider_websocket_secure = true

--- a/test/e2e/prosody-e2e.cfg.lua
+++ b/test/e2e/prosody-e2e.cfg.lua
@@ -1,3 +1,6 @@
 -- E2E-only settings. The test network is private to Docker Compose.
+-- Prosody intentionally binds unencrypted HTTP to loopback by default; expose
+-- it to the private Compose network so XMPP-over-WebSocket is reachable.
+http_interfaces = { "0.0.0.0", "::" }
 c2s_require_encryption = false
 consider_websocket_secure = true

--- a/test/e2e/run.mjs
+++ b/test/e2e/run.mjs
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { createHmac, randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+
+const require = createRequire("/opt/mx-puppet-xmpp/package.json");
+const { client, xml } = require("@xmpp/client");
+
+const MATRIX_URL = process.env.MATRIX_URL || "http://synapse:8008";
+const MATRIX_DOMAIN = process.env.MATRIX_DOMAIN || "matrix.test";
+const MATRIX_SECRET = process.env.MATRIX_REGISTRATION_SECRET || "e2e-registration-secret";
+const XMPP_URL = process.env.XMPP_URL || "ws://prosody:5280/xmpp-websocket";
+const XMPP_DOMAIN = process.env.XMPP_DOMAIN || "xmpp.test";
+
+const MATRIX_USER = "alice";
+const MATRIX_PASSWORD = "matrixpass";
+const MATRIX_MXID = `@${MATRIX_USER}:${MATRIX_DOMAIN}`;
+const BOT_MXID = `@_xmpppuppet_bot:${MATRIX_DOMAIN}`;
+const PUPPET_JID = `alice@${XMPP_DOMAIN}`;
+const PUPPET_PASSWORD = "alicepass";
+const REMOTE_JID = `bob@${XMPP_DOMAIN}`;
+const REMOTE_PASSWORD = "bobpass";
+const TIMEOUT_MS = 45_000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function request(path, { method = "GET", token, body, expected = [200] } = {}) {
+    const headers = {};
+    if (token) headers.authorization = `Bearer ${token}`;
+    if (body !== undefined) headers["content-type"] = "application/json";
+    const response = await fetch(`${MATRIX_URL}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    let parsed = null;
+    if (text) {
+        try {
+            parsed = JSON.parse(text);
+        } catch {
+            parsed = text;
+        }
+    }
+    if (!expected.includes(response.status)) {
+        throw new Error(`${method} ${path} returned ${response.status}: ${text}`);
+    }
+    return parsed;
+}
+
+async function retry(name, fn, timeoutMs = TIMEOUT_MS) {
+    const deadline = Date.now() + timeoutMs;
+    let lastError;
+    while (Date.now() < deadline) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastError = err;
+            await sleep(500);
+        }
+    }
+    throw new Error(`${name} timed out: ${lastError?.message || lastError || "condition not met"}`);
+}
+
+async function registerMatrixUser() {
+    const { nonce } = await request("/_synapse/admin/v1/register");
+    const mac = createHmac("sha1", MATRIX_SECRET);
+    mac.update(nonce);
+    mac.update("\0");
+    mac.update(MATRIX_USER);
+    mac.update("\0");
+    mac.update(MATRIX_PASSWORD);
+    mac.update("\0");
+    mac.update("notadmin");
+    await request("/_synapse/admin/v1/register", {
+        method: "POST",
+        body: {
+            nonce,
+            username: MATRIX_USER,
+            password: MATRIX_PASSWORD,
+            admin: false,
+            mac: mac.digest("hex"),
+        },
+    });
+}
+
+async function loginMatrix() {
+    const response = await request("/_matrix/client/v3/login", {
+        method: "POST",
+        body: {
+            type: "m.login.password",
+            identifier: { type: "m.id.user", user: MATRIX_MXID },
+            password: MATRIX_PASSWORD,
+            initial_device_display_name: "mx-puppet-xmpp e2e",
+        },
+    });
+    assert.equal(response.user_id, MATRIX_MXID);
+    return response.access_token;
+}
+
+async function waitForBot(token) {
+    await retry("bridge bot registration", async () => {
+        await request(`/_matrix/client/v3/profile/${encodeURIComponent(BOT_MXID)}`, {
+            token,
+            expected: [200],
+        });
+    });
+}
+
+async function createStatusRoom(token) {
+    const response = await request("/_matrix/client/v3/createRoom", {
+        method: "POST",
+        token,
+        body: {
+            preset: "trusted_private_chat",
+            is_direct: true,
+            invite: [BOT_MXID],
+            name: "XMPP bridge E2E status",
+        },
+    });
+    const roomId = response.room_id;
+    await retry("bridge bot joining status room", async () => {
+        const member = await request(
+            `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent(BOT_MXID)}`,
+            { token },
+        );
+        assert.equal(member.membership, "join");
+    });
+    return roomId;
+}
+
+async function sendMatrixText(token, roomId, body) {
+    const txn = randomUUID();
+    await request(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${encodeURIComponent(txn)}`,
+        {
+            method: "PUT",
+            token,
+            body: { msgtype: "m.text", body },
+        },
+    );
+}
+
+async function recentRoomMessages(token, roomId) {
+    const response = await request(
+        `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/messages?dir=b&limit=50`,
+        { token },
+    );
+    return response.chunk || [];
+}
+
+async function waitForRoomMessage(token, roomId, predicate, name) {
+    return retry(name, async () => {
+        const events = await recentRoomMessages(token, roomId);
+        const event = events.find((candidate) => (
+            candidate.type === "m.room.message" &&
+            candidate.sender !== MATRIX_MXID &&
+            predicate(candidate.content?.body || "")
+        ));
+        assert.ok(event, "message not present yet");
+        return event;
+    });
+}
+
+async function waitForRemoteRoom(token, statusRoomId) {
+    let since;
+    const knownJoined = new Set([statusRoomId]);
+    return retry("remote Matrix DM creation", async () => {
+        const suffix = new URLSearchParams({ timeout: "1000" });
+        if (since) suffix.set("since", since);
+        const sync = await request(`/_matrix/client/v3/sync?${suffix}`, { token });
+        since = sync.next_batch;
+
+        for (const roomId of Object.keys(sync.rooms?.join || {})) {
+            knownJoined.add(roomId);
+        }
+        for (const roomId of Object.keys(sync.rooms?.invite || {})) {
+            await request(`/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/join`, {
+                method: "POST",
+                token,
+                body: {},
+            });
+            knownJoined.add(roomId);
+        }
+
+        const candidates = [...knownJoined].filter((roomId) => roomId !== statusRoomId);
+        assert.ok(candidates.length > 0, "remote room not visible yet");
+        return candidates[0];
+    });
+}
+
+function bareJid(jid) {
+    return jid.split("/", 1)[0];
+}
+
+async function connectXmpp(username, password, resource) {
+    return retry(`XMPP login for ${username}`, async () => {
+        const api = client({
+            service: XMPP_URL,
+            domain: XMPP_DOMAIN,
+            username,
+            password,
+            resource,
+        });
+        try {
+            await new Promise((resolve, reject) => {
+                const timer = setTimeout(() => reject(new Error("XMPP online timeout")), 8_000);
+                api.once("online", () => {
+                    clearTimeout(timer);
+                    resolve();
+                });
+                api.once("error", (err) => {
+                    clearTimeout(timer);
+                    reject(err);
+                });
+                Promise.resolve(api.start()).catch(reject);
+            });
+            await api.send(xml("presence"));
+            return api;
+        } catch (err) {
+            try { await api.stop(); } catch {}
+            throw err;
+        }
+    });
+}
+
+function waitForXmppBody(api, expectedBody, expectedFrom) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            api.removeListener("stanza", onStanza);
+            reject(new Error(`Did not receive XMPP body: ${expectedBody}`));
+        }, TIMEOUT_MS);
+        const onStanza = (stanza) => {
+            if (!stanza.is("message")) return;
+            const body = stanza.getChild("body");
+            if (!body || body.text() !== expectedBody) return;
+            if (expectedFrom && bareJid(stanza.attrs.from || "") !== expectedFrom) return;
+            clearTimeout(timer);
+            api.removeListener("stanza", onStanza);
+            resolve(stanza);
+        };
+        api.on("stanza", onStanza);
+    });
+}
+
+async function runCase(name, fn) {
+    const started = Date.now();
+    process.stdout.write(`E2E ${name} ... `);
+    await fn();
+    console.log(`ok (${Date.now() - started} ms)`);
+}
+
+let bob;
+try {
+    await retry("Synapse readiness", async () => {
+        await request("/_matrix/client/versions");
+    });
+    await registerMatrixUser();
+    const token = await loginMatrix();
+    await waitForBot(token);
+    const statusRoom = await createStatusRoom(token);
+
+    await runCase("rejects invalid XMPP credentials", async () => {
+        await sendMatrixText(token, statusRoom, `link ${PUPPET_JID} definitely-wrong`);
+        await waitForRoomMessage(
+            token,
+            statusRoom,
+            (body) => body.includes("ERROR: Could not authenticate to XMPP"),
+            "invalid-login response",
+        );
+    });
+
+    await runCase("links a valid XMPP account", async () => {
+        await sendMatrixText(token, statusRoom, `link ${PUPPET_JID} ${PUPPET_PASSWORD}`);
+        await waitForRoomMessage(
+            token,
+            statusRoom,
+            (body) => body.includes("Created new link with ID"),
+            "successful-link response",
+        );
+    });
+
+    bob = await connectXmpp("bob", REMOTE_PASSWORD, `e2e-${randomUUID()}`);
+
+    await runCase("ignores body-less XMPP stanzas", async () => {
+        await bob.send(xml(
+            "message",
+            { type: "chat", to: PUPPET_JID },
+            xml("active", { xmlns: "http://jabber.org/protocol/chatstates" }),
+        ));
+        await sleep(500);
+        const bootstrap = `bootstrap-${randomUUID()}`;
+        await bob.send(xml(
+            "message",
+            { type: "chat", to: PUPPET_JID, id: randomUUID() },
+            xml("body", {}, bootstrap),
+        ));
+    });
+
+    const remoteRoom = await waitForRemoteRoom(token, statusRoom);
+
+    await runCase("bridges XMPP to Matrix", async () => {
+        const body = `xmpp-to-matrix-${randomUUID()}`;
+        await bob.send(xml(
+            "message",
+            { type: "chat", to: PUPPET_JID, id: randomUUID() },
+            xml("body", {}, body),
+        ));
+        await waitForRoomMessage(
+            token,
+            remoteRoom,
+            (candidate) => candidate === body,
+            "XMPP to Matrix delivery",
+        );
+    });
+
+    await runCase("bridges Matrix to XMPP", async () => {
+        const body = `matrix-to-xmpp-${randomUUID()}`;
+        const received = waitForXmppBody(bob, body, PUPPET_JID);
+        await sendMatrixText(token, remoteRoom, body);
+        await received;
+    });
+
+    console.log("E2E suite passed: 5/5 cases");
+} finally {
+    if (bob) {
+        try { await bob.stop(); } catch {}
+    }
+}

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+COMPOSE_FILE="test/e2e/compose.yaml"
+
+compose() {
+    docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+cleanup() {
+    status=$?
+    trap - EXIT INT TERM
+    if [ "$status" -ne 0 ]; then
+        echo "\nE2E failed; compose state:" >&2
+        compose ps >&2 || true
+        echo "\nE2E service logs:" >&2
+        compose logs --no-color >&2 || true
+    fi
+    compose down -v --remove-orphans >/dev/null 2>&1 || true
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+compose config >/dev/null
+compose up -d --build bridge synapse prosody
+compose run --rm --no-deps e2e

--- a/test/e2e/synapse-overrides.yaml
+++ b/test/e2e/synapse-overrides.yaml
@@ -1,4 +1,9 @@
 registration_shared_secret: e2e-registration-secret
 app_service_config_files:
   - /bridge/xmpp-registration.yaml
+# mx-puppet-bridge 0.1.6 still authenticates homeserver -> appservice
+# requests with the legacy access_token query parameter. Modern Synapse sends
+# the spec-compliant Authorization header by default; enable its compatibility
+# mode in this isolated E2E homeserver until the bridge framework is replaced.
+use_appservice_legacy_authorization: true
 suppress_key_server_warning: true

--- a/test/e2e/synapse-overrides.yaml
+++ b/test/e2e/synapse-overrides.yaml
@@ -1,0 +1,4 @@
+registration_shared_secret: e2e-registration-secret
+app_service_config_files:
+  - /bridge/xmpp-registration.yaml
+suppress_key_server_warning: true


### PR DESCRIPTION
## What changed

- add a self-contained Docker Compose E2E environment with Synapse, Prosody, the bridge, and a black-box Node test runner
- generate the Matrix application-service registration automatically before Synapse starts
- provision isolated Matrix and XMPP test users automatically
- exercise the real bridge bot `link` flow instead of seeding the bridge database
- add five E2E cases covering invalid credentials, successful linking, body-less XMPP stanzas, XMPP → Matrix delivery, and Matrix → XMPP delivery
- dump Compose state/logs on failure and tear down containers + volumes on every run
- add `npm run test:e2e` and a dedicated GitHub Actions E2E workflow

## Test topology

- Synapse `v1.158.0`
- Prosody 13.0 image on an isolated Compose network
- current branch bridge image
- no host ports or external services required

The XMPP WebSocket is intentionally plain `ws://` inside the private test network and is enabled only through the bridge's development-only insecure-WebSocket switch.

## Validation

The new E2E workflow will validate the full Compose stack on this PR. Existing CI, CodeQL, and Docker workflows continue to run independently.